### PR TITLE
Snowflake test check connection basic exceptions

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -9,11 +9,11 @@ acceptance_tests:
       - config_path: "secrets/config.json"
         status: "succeed"
       - config_path: "secrets/invalid_config.json"
-        status: "exception"
+        status: "failed"
       - config_path: "secrets/incorrect_host_format_config.json"
-        status: "exception"
+        status: "failed"
       - config_path: "secrets/duplicated_push_down_filters_config.json"
-        status: "exception"
+        status: "failed"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -8,6 +8,10 @@ acceptance_tests:
     tests:
       - config_path: "secrets/config.json"
         status: "succeed"
+      - config_path: "secrets/incorrect_host_format_config.json"
+        status: "exception"
+      - config_path: "secrets/duplicated_push_down_filters_config.json"
+        status: "exception"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -8,6 +8,8 @@ acceptance_tests:
     tests:
       - config_path: "secrets/config.json"
         status: "succeed"
+      - config_path: "secrets/invalid_config.json"
+        status: "exception"
       - config_path: "secrets/incorrect_host_format_config.json"
         status: "exception"
       - config_path: "secrets/duplicated_push_down_filters_config.json"

--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -10,6 +10,8 @@ acceptance_tests:
         status: "succeed"
       - config_path: "secrets/invalid_config.json"
         status: "failed"
+      - config_path: "secrets/invalid_private_key_config.json"
+        status: "failed"
       - config_path: "secrets/incorrect_host_format_config.json"
         status: "failed"
       - config_path: "secrets/duplicated_push_down_filters_config.json"

--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -18,7 +18,9 @@ acceptance_tests:
         status: "failed"
       - config_path: "secrets/inconsistent_parent_name_push_down_filters_config.json"
         status: "failed"
-      - config_path: "secrets/unknown_update_method_config.json.json"
+      - config_path: "secrets/unknown_update_method_config.json"
+        status: "failed"
+      - config_path: "secrets/unknown_schema_config.json"
         status: "failed"
   discovery:
     tests:

--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -16,6 +16,8 @@ acceptance_tests:
         status: "failed"
       - config_path: "secrets/duplicated_push_down_filters_config.json"
         status: "failed"
+      - config_path: "secrets/inconsistent_parent_name_push_down_filters_config.json"
+        status: "failed"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-snowflake/acceptance-test-config.yml
@@ -18,6 +18,8 @@ acceptance_tests:
         status: "failed"
       - config_path: "secrets/inconsistent_parent_name_push_down_filters_config.json"
         status: "failed"
+      - config_path: "secrets/unknown_update_method_config.json.json"
+        status: "failed"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/example_valid_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/example_valid_config.json
@@ -7,5 +7,8 @@
     "streams": [],
     "host": "https://XXXXXXXXXXX.snowflakecomputing.com",
     "role": "ROLE",
-    "warehouse": "WAREHOUSE"
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
 }

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/duplicated_push_down_filters_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/duplicated_push_down_filters_config.json
@@ -18,5 +18,8 @@
     ],
     "host": "https://XXXXXXXXXXX.snowflakecomputing.com",
     "role": "ROLE",
-    "warehouse": "WAREHOUSE"
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
 }

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/duplicated_push_down_filters_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/duplicated_push_down_filters_config.json
@@ -1,0 +1,22 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "USER NAME",
+        "private_key": "-----BEGIN PRIVATE KEY----- your key content -----END PRIVATE KEY-----"
+    },
+    "streams": [
+        {
+            "name": "push_down_1",
+            "parent_stream": "INTEGRATION_TEST.TEST_TABLE",
+            "where_clause": "ID>2"
+        },
+        {
+            "name": "push_down_1",
+            "parent_stream": "INTEGRATION_TEST.TEST_TABLE",
+            "where_clause": "ID>5"
+        }
+    ],
+    "host": "https://XXXXXXXXXXX.snowflakecomputing.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE"
+}

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/inconsistent_parent_name_push_down_filters_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/inconsistent_parent_name_push_down_filters_config.json
@@ -1,0 +1,20 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "USER NAME",
+        "private_key": "-----BEGIN PRIVATE KEY----- your key content -----END PRIVATE KEY-----"
+    },
+    "streams": [
+        {
+            "name": "push_down_1",
+            "parent_stream": "Bad parent stream name",
+            "where_clause": "ID>2"
+        }
+    ],
+    "host": "https://XXXXXXXXXXX.snowflakecomputing.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
+}

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/incorrect_host_format_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/incorrect_host_format_config.json
@@ -1,0 +1,14 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "USER NAME",
+        "private_key": "-----BEGIN PRIVATE KEY----- your key content -----END PRIVATE KEY-----"
+    },
+    "streams": [],
+    "host": "https://XXXXXXXXXXX.not_right_domain.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
+}

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/invalid_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/invalid_config.json
@@ -1,0 +1,14 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "BAD USER NAME",
+        "private_key": "BAD KEY"
+    },
+    "streams": [],
+    "host": "https://XXXXXXXXXXX.not_right_domain.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
+}

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/invalid_private_key_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/invalid_private_key_config.json
@@ -1,0 +1,14 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "USER NAME",
+        "private_key": "BAD KEY"
+    },
+    "streams": [],
+    "host": "https://XXXXXXXXXXX..snowflakecomputing.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
+}

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/unknown_schema_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/unknown_schema_config.json
@@ -1,0 +1,14 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "USER NAME",
+        "private_key": "-----BEGIN PRIVATE KEY----- your key content -----END PRIVATE KEY-----"
+    },
+    "streams": [],
+    "host": "https://XXXXXXXXXXX.snowflakecomputing.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "BAD SCHEMA",
+    "replication_method":{"method":"standard"}
+}

--- a/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/unknown_update_method_config.json
+++ b/airbyte-integrations/connectors/source-snowflake/integration_tests/resources/unknown_update_method_config.json
@@ -1,0 +1,14 @@
+{
+    "credentials": {
+        "auth_type": "JWT Token",
+        "user_name": "USER NAME",
+        "private_key": "-----BEGIN PRIVATE KEY----- your key content -----END PRIVATE KEY-----"
+    },
+    "streams": [],
+    "host": "https://XXXXXXXXXXX.snowflakecomputing.com",
+    "role": "ROLE",
+    "warehouse": "WAREHOUSE",
+    "database": "DATABASE",
+    "schema": "SCHEMA",
+    "replication_method":{"method":"standard"}
+}

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/snowflake_exceptions.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/snowflake_exceptions.py
@@ -51,6 +51,13 @@ class UnknownUpdateMethodError(Exception):
         self.unknown_update_method = unknown_update_method
 
 
+class BadPrivateKeyFormatError(Exception):
+    """
+    This error happens when the user provides a url without the suffix ".snowflakecomputing.com"
+    """
+    pass
+
+
 #######################################################
 ######### Stream Errors errors
 #######################################################

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/source.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/source.py
@@ -80,7 +80,7 @@ class SourceSnowflake(AbstractSource):
                                  "- The configuration provided does not have enough permissions to access the requested database/schema.\n"
                                  "- The configuration is not consistent (example: schema not present is database.")
 
-            if int(error_code) == 404:
+            if int(error_code) == 401:
                 error_message = "401 Client Error: Unauthorized for url. Make sure you are using the correct credentials"
 
             if int(error_code) == 422:

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/source.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/source.py
@@ -81,7 +81,7 @@ class SourceSnowflake(AbstractSource):
                                  "- The configuration is not consistent (example: schema not present is database.")
 
             if int(error_code) == 401:
-                error_message = "401 Client Error: Unauthorized for url. Make sure you are using the correct credentials"
+                error_message = "401 Client Error: Unauthorized for url. Make sure the credentials are valid and correct"
 
             if int(error_code) == 422:
                 try:

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/source.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/source.py
@@ -15,7 +15,8 @@ from airbyte_protocol.models import SyncMode, AirbyteMessage, AirbyteTraceMessag
 from airbyte_cdk.models import Type as AirbyteType
 from .authenticator import SnowflakeJwtAuthenticator
 from .snowflake_exceptions import InconsistentPushDownFilterParentStreamNameError, NotEnabledChangeTrackingOptionError, \
-    DuplicatedPushDownFilterStreamNameError, IncorrectHostFormat, emit_airbyte_error_message, UnknownUpdateMethodError
+    DuplicatedPushDownFilterStreamNameError, IncorrectHostFormat, emit_airbyte_error_message, UnknownUpdateMethodError, \
+    BadPrivateKeyFormatError
 from .streams.push_down_filter_stream import PushDownFilterStream, PushDownFilterChangeDataCaptureStream
 from .utils import handle_no_permissions_error
 
@@ -39,16 +40,20 @@ class SourceSnowflake(AbstractSource):
         try:
             host = config['host']
             self.check_host_format(host)
+            authenticator = SnowflakeJwtAuthenticator.from_config(config)
             self.check_update_method(config=config)
             self.check_push_down_filter_name_unicity(config=config)
             url_base = self.format_url_base(host)
-            authenticator = SnowflakeJwtAuthenticator.from_config(config)
 
             self.check_existence_of_at_least_one_stream(url_base=url_base, config=config, authenticator=authenticator)
             self.check_push_down_filters_parent_stream_consistency(url_base=url_base, config=config, authenticator=authenticator)
 
         except IncorrectHostFormat:
-            error_message = f"your host is not ending with {self.SNOWFLAKE_URL_SUFFIX}"
+            error_message = f"The host provided is not ending with {self.SNOWFLAKE_URL_SUFFIX}"
+
+        except BadPrivateKeyFormatError:
+            error_message = (f'There is an error with the provided private key, it could not be decoded. Please make sure you respect '
+                             f'the PEM format')
 
         except UnknownUpdateMethodError as e:
             error_message = f'Update method {e.unknown_update_method} not recognized'
@@ -57,7 +62,7 @@ class SourceSnowflake(AbstractSource):
             error_message = 'There are pushdown filters with same name which is not possible'
 
         except InconsistentPushDownFilterParentStreamNameError as e:
-            error_message = (f'You have provided inconsistent pushdown filters configuration. Parent stream not found or mistake in  '
+            error_message = (f'There is an inconsistency in the pushdown filters configuration. Parent stream not found or mistake in  '
                              f'spelling parent stream name. Correct spelling must be your_schema_name.your_table_name and make sure '
                              f'you have the rights to read the table.\n. Here is the '
                              f'list of the streams affected by this error: {e.push_down_filters_without_consistent_parent}')


### PR DESCRIPTION
## What

Adding test of basic checks: 

- invalid config
- invalid private key
- invalid host name
- duplicated push down filter name
- inconsistent parent stream name
- invalid update method
- unknown schema

Handling error 401 in check connection 

The status is set to failed for error cases

In this folder: integration_tests/resources, you will find configs that you can set for test with dummy values for secrets.

