### PR TITLE
Snow full refresh with cursor

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/poetry.lock
+++ b/airbyte-integrations/connectors/source-snowflake/poetry.lock
@@ -720,6 +720,20 @@ files = [
 ]
 
 [[package]]
+name = "parameterized"
+version = "0.9.0"
+description = "Parameterized testing with any Python test framework"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "parameterized-0.9.0-py2.py3-none-any.whl", hash = "sha256:4e0758e3d41bea3bbd05ec14fc2c24736723f243b28d702081aef438c9372b1b"},
+    {file = "parameterized-0.9.0.tar.gz", hash = "sha256:7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1"},
+]
+
+[package.extras]
+dev = ["jinja2"]
+
+[[package]]
 name = "pendulum"
 version = "2.1.2"
 description = "Python datetimes made easy"
@@ -1324,4 +1338,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "74d12cef129933d486570df9aa35dc9dd90915328a18fbd9b965ae1728644227"
+content-hash = "90f4661cd074af6539bd31a0f1930b28f64825207769b9fd94090b5750050512"

--- a/airbyte-integrations/connectors/source-snowflake/pyproject.toml
+++ b/airbyte-integrations/connectors/source-snowflake/pyproject.toml
@@ -26,4 +26,5 @@ requests-mock = "*"
 pytest-mock = "*"
 pytest = "*"
 jsonpath-ng = "^1.6.1"
+parameterized = "^0.9.0"
 

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/schema_builder.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/schema_builder.py
@@ -150,7 +150,7 @@ def format_field(field_value, field_type, local_time_zone_offset_hours=None):
     if field_type.upper() in ('OBJECT', 'ARRAY'):
         return json.loads(field_value)
 
-    if field_type.upper() in date_and_time_snowflake_type_airbyte_type.keys() and field_value:
+    if field_type.upper() in date_and_time_snowflake_type_airbyte_type.keys():
 
         if isinstance(field_value, datetime):  # Already formatted date
             return field_value

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/schema_builder.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/schema_builder.py
@@ -24,7 +24,7 @@ def get_generic_type_from_schema_type(schema_type):
     if schema_type == SchemaTypes.timestamp_with_timezone:
         return "timestamp_with_timezone"
 
-    if schema_type in (SchemaTypes.timestamp_without_timezone, SchemaTypes.time_without_timezone):
+    if schema_type in (SchemaTypes.timestamp_without_timezone, SchemaTypes.time_without_timezone, SchemaTypes.date):
         return "date"
 
     if schema_type in (SchemaTypes.number, SchemaTypes.integer, SchemaTypes.boolean):

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/table_stream.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/table_stream.py
@@ -339,6 +339,7 @@ class TableStream(SnowflakeStream, IncrementalMixin):
 
         if self.state is not None and len(self.state) > 0:
             current_state_value = self.state[self.cursor_field]
+            print("get_state",latest_record_state, current_state_value)
             self._state_value = max(latest_record_state,
                                     current_state_value) if current_state_value is not None else latest_record_state
             self.state = {self.cursor_field: self._state_value}

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/table_stream.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/table_stream.py
@@ -339,7 +339,6 @@ class TableStream(SnowflakeStream, IncrementalMixin):
 
         if self.state is not None and len(self.state) > 0:
             current_state_value = self.state[self.cursor_field]
-            print("get_state",latest_record_state, current_state_value)
             self._state_value = max(latest_record_state,
                                     current_state_value) if current_state_value is not None else latest_record_state
             self.state = {self.cursor_field: self._state_value}

--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/util_streams.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/util_streams.py
@@ -261,12 +261,12 @@ class StreamLauncher(SnowflakeStream):
         if not self._json_schema_set:
             self.get_json_schema()
 
-        if self.cursor_field.upper() not in self._json_schema['properties']:
+        if self.cursor_field not in self._json_schema['properties']:
             error_message = f'this field {self.cursor_field} should be present in schema. Make sure the column is present in your stream'
             emit_airbyte_error_message(error_message)
             raise CursorFieldNotPresentInSchemaError(error_message)
 
-        schema_type = self._json_schema['properties'][self.cursor_field.upper()]
+        schema_type = self._json_schema['properties'][self.cursor_field]
 
         generic_type = get_generic_type_from_schema_type(schema_type)
 
@@ -319,6 +319,7 @@ class StreamLauncher(SnowflakeStream):
         for column_object in self.table_schema_stream.read_records(sync_mode=SyncMode.full_refresh):
             column_name = column_object['column_name']
             snowflake_column_type = column_object['type'].upper()
+
             if snowflake_column_type not in mapping_snowflake_type_airbyte_type:
                 error_message = (f"The type {snowflake_column_type} is not recognized. "
                                  f"Please, contact Airbyte support to update the connector to handle this new type")

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/configured_snowflake_streamBuilder.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/configured_snowflake_streamBuilder.py
@@ -1,0 +1,9 @@
+from airbyte_cdk.test.catalog_builder import ConfiguredAirbyteStreamBuilder
+
+
+
+class SnowflakeStreamBuilder(ConfiguredAirbyteStreamBuilder):
+
+    def with_cursor_field(self, cursor_field: list[str]) -> "SnowflakeStreamBuilder":
+        self._stream["cursor_field"] = cursor_field
+        return self

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/mocker.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/mocker.py
@@ -21,6 +21,8 @@ class CustomHttpMocker(HttpMocker):
 
     def __exit__(self, exc_type: Optional[BaseException], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> None:
         self._mocker.__exit__(exc_type, exc_val, exc_tb)
+        
+        
         if exc_type == requests_mock.NoMockAddress :
             matchers_as_string = "\n\t".join(map(lambda matcher: str(matcher.request), self._matchers))
             error_to_raise =  ValueError(
@@ -28,7 +30,7 @@ class CustomHttpMocker(HttpMocker):
                 f"and body `{exc_val.request.body}`. "
                 f"Matchers currently configured are:\n\t{matchers_as_string}."
             )
-
+        
         try:
             self._validate_all_matchers_called()
         except ValueError as http_mocker_exception:
@@ -36,7 +38,9 @@ class CustomHttpMocker(HttpMocker):
             # the output is the function call that failed the assertion, whereas raising `ValueError(http_mocker_exception)`
             # like we do here provides additional context for the exception.
             raise ValueError(http_mocker_exception) from None
-        if exc_val == AssertionError:
+
+        
+        if exc_type == AssertionError:
             return False
 
     # trying to type that using callables provides the error `incompatible with return type "_F" in supertype "ContextDecorator"`

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/mocker.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/mocker.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import contextlib
+import functools
+from enum import Enum
+from types import TracebackType
+from typing import Callable, List, Optional, Union
+from airbyte_cdk.test.mock_http import HttpMocker
+
+import requests_mock
+from airbyte_cdk.test.mock_http import HttpRequest, HttpRequestMatcher, HttpResponse
+
+
+class SupportedHttpMethods(str, Enum):
+    GET = "get"
+    POST = "post"
+    DELETE = "delete"
+
+
+class CustomHttpMocker(HttpMocker):
+
+    def __exit__(self, exc_type: Optional[BaseException], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> None:
+        self._mocker.__exit__(exc_type, exc_val, exc_tb)
+        if exc_type == requests_mock.NoMockAddress :
+            matchers_as_string = "\n\t".join(map(lambda matcher: str(matcher.request), self._matchers))
+            error_to_raise =  ValueError(
+                f"No matcher matches {exc_val.args[0]} with headers `{exc_val.request.headers}` "
+                f"and body `{exc_val.request.body}`. "
+                f"Matchers currently configured are:\n\t{matchers_as_string}."
+            )
+
+        try:
+            self._validate_all_matchers_called()
+        except ValueError as http_mocker_exception:
+            # This seems useless as it catches ValueError and raises ValueError but without this, the prevailing error message in
+            # the output is the function call that failed the assertion, whereas raising `ValueError(http_mocker_exception)`
+            # like we do here provides additional context for the exception.
+            raise ValueError(http_mocker_exception) from None
+        if exc_val == AssertionError:
+            return False
+
+    # trying to type that using callables provides the error `incompatible with return type "_F" in supertype "ContextDecorator"`
+    def __call__(self, f):  # type: ignore
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):  # type: ignore  # this is a very generic wrapper that does not need to be typed
+            with self:
+                assertion_error = None
+
+                kwargs["http_mocker"] = self
+                result = f(*args, **kwargs)
+                
+                return result
+
+        return wrapper

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/request_builder.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/request_builder.py
@@ -31,6 +31,7 @@ class SnowflakeRequestBuilder:
         self._timezone = False
         self._partition = None
         self._where_statement = None
+        self._order_by = None
 
     def with_table(self, table: str):
         self._table = table
@@ -71,9 +72,13 @@ class SnowflakeRequestBuilder:
     def with_where_statement(self, where_statement: str):
         self._where_statement = where_statement
         return self
-
-    def _build_query_params(self, is_get: bool = False):
-        query_params = {"requestId": self._requestID, "async": self._async}
+    
+    def with_order_by(self, columns:list[str]):
+        self._order_by = columns
+        return self
+    
+    def _build_query_params(self,is_get:bool=False):
+        query_params = {"requestId":self._requestID, "async":self._async}
         if is_get:
             if self._partition:
                 query_params = {"partition": self._partition}
@@ -86,9 +91,7 @@ class SnowflakeRequestBuilder:
         query_params = self._build_query_params(is_get)
         statement = None
         if self._table:
-            statement = f'SELECT * FROM "{self._database}"."{self._schema}"."{self._table}"'
-            if self._where_statement:
-                statement = f"{statement} WHERE {self._where_statement}"
+            statement = f'SELECT * FROM "{self._database}"."{self._schema}"."{self._table}"{" WHERE " + self._where_statement if self._where_statement else ""}{" ORDER BY " + ",".join(self._order_by) +" ASC" if self._order_by else ""}'
         if self._show_catalog:
             statement = f"SHOW TABLES IN SCHEMA {self._database}.{self._schema}"
         if self._show_primary_keys and self._table:

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/response_builder.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/response_builder.py
@@ -20,7 +20,6 @@ class JsonPath(Path):
         self._path.update(template, value)
     
     def extract(self, template: Dict[str, Any]) -> Any:
-
         a = [match.value for match in self._path.find(template)]
         return a
 

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -270,7 +270,14 @@ class FullRefreshTest(TestCase):
     @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
     @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
     @HttpMocker()
-    def test_retry_on_get_error(self, error_code, property_mock, uuid_mock, mock_auth, http_mocker: HttpMocker) -> None:
+    def test_retry_on_get_error(
+        self, 
+        error_code, 
+        property_mock, 
+        uuid_mock, 
+        mock_auth, 
+        http_mocker: 
+        HttpMocker) -> None:
         _given_get_timezone(http_mocker)
         _given_read_schema(http_mocker)
         _given_table_catalog(http_mocker)
@@ -314,7 +321,14 @@ class FullRefreshTest(TestCase):
     @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
     @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
     @HttpMocker()
-    def test_fail_on_post_error_and_max_retry(self,error_code, mock_retries, mock_time, uuid_mock, mock_auth, http_mocker: HttpMocker) -> None:
+    def test_fail_on_post_error_and_max_retry(
+        self,
+        error_code, 
+        mock_retries, 
+        mock_time, 
+        uuid_mock, 
+        mock_auth, 
+        http_mocker: HttpMocker) -> None:
         _given_get_timezone(http_mocker)
         _given_read_schema(http_mocker)
         _given_table_catalog(http_mocker)

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -140,11 +140,11 @@ class FullRefreshTest(TestCase):
             table_request().with_table(_TABLE).with_requestID(_REQUESTID).with_async().build(),
             snowflake_response("async_response", FieldPath("statementStatusUrl")).with_handle(_HANDLE).build()
         )
-        # self._http_mocker.get(
-        #     table_request().with_handle(_HANDLE).build(is_get=True),
-        #     snowflake_response("response_get_table", JsonPath("$.'data'"))
-        #     .with_record( a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]")))
-        #     .build())
+        self._http_mocker.get(
+            table_request().with_handle(_HANDLE).build(is_get=True),
+            snowflake_response("response_get_table", JsonPath("$.'data'"))
+            .with_record( a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]")))
+            .build())
         
         
 
@@ -168,11 +168,6 @@ class FullRefreshTest(TestCase):
         )
         self._http_mocker.get(
             table_request().with_handle(_HANDLE).with_partition(2).build(is_get=True),
-            snowflake_response("response_get_table", JsonPath("$.'data'")).with_record(
-                a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]"))).with_pagination().build()
-        )
-        self._http_mocker.get(
-            table_request().with_handle("123").with_partition(18).build(is_get=True),
             snowflake_response("response_get_table", JsonPath("$.'data'")).with_record(
                 a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]"))).with_pagination().build()
         )
@@ -277,18 +272,6 @@ class FullRefreshTest(TestCase):
         self._http_mocker.get(
             table_request()
             .with_handle(_HANDLE)
-            .build(is_get=True),
-            [
-            snowflake_response("response_get_table",JsonPath("$.'data'"))
-            .with_record(a_snowflake_response("response_get_table",JsonPath("$.'data'[*]")))
-            .with_status_code(error_code).build(),
-            snowflake_response("response_get_table",JsonPath("$.'data'"))
-            .with_record(a_snowflake_response("response_get_table",JsonPath("$.'data'[*]"))).build(),
-            ]
-        )
-        self._http_mocker.get(
-            table_request()
-            .with_handle("123")
             .build(is_get=True),
             [
             snowflake_response("response_get_table",JsonPath("$.'data'"))

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -120,10 +120,13 @@ def _read(
 
 
 class FullRefreshTest(TestCase):
+        
+
+
     @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
     @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
     @HttpMocker()
-    def test_given_one_page_when_read_then_return_records(self, uuid_mock, mock_auth, http_mocker: HttpMocker) -> None:
+    def test_given_one_page_when_read_then_return_records(self, uuid_mock, mock_auth,http_mocker) -> None:
         _given_get_timezone(http_mocker)
         _given_read_schema(http_mocker)
         _given_table_catalog(http_mocker)
@@ -196,7 +199,7 @@ class FullRefreshTest(TestCase):
         http_mocker: HttpMocker,
         ) -> None:
 
-        def snowflake_record():
+        def a_record():
             return a_snowflake_response("response_get_table",JsonPath("$.'data'[*]"), cursor_path=JsonPath(f"$.[{cursor_index}]"))
 
         _given_get_timezone(http_mocker)
@@ -211,10 +214,10 @@ class FullRefreshTest(TestCase):
             table_request().with_handle(_HANDLE).build(is_get=True),
             snowflake_response("response_get_table",JsonPath("$.'data'"))
              .with_record(
-                 snowflake_record()
+                 a_record()
                  .with_cursor(value_first_record))
              .with_record(
-                 snowflake_record()
+                 a_record()
                  .with_cursor(value_second_record))
              .build()
             )
@@ -255,6 +258,7 @@ class FullRefreshTest(TestCase):
             snowflake_response("response_get_table",JsonPath("$.'data'")).with_record(a_snowflake_response("response_get_table",JsonPath("$.'data'[*]"))).build()
         )
         output = _read(_config(), sync_mode=SyncMode.full_refresh)
+        assert len(output.records) == 1
 
     
 
@@ -306,6 +310,7 @@ class FullRefreshTest(TestCase):
             ]
         )
         output = _read(_config(), sync_mode=SyncMode.full_refresh)
+        assert len(output.records) == 1
     
     @parameterized.expand(
             [

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -9,7 +9,7 @@ from airbyte_cdk.test.catalog_builder import CatalogBuilder
 from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
 from inflection import parameterize
 from integration.response_builder import JsonPath, SnowflakeResponseBuilder, create_response_builder
-from integration.mocker import HttpMocker
+from integration.mocker import CustomHttpMocker, HttpMocker
 from airbyte_cdk.test.mock_http.response_builder import (
     FieldPath,
     Path,
@@ -124,7 +124,7 @@ def _read(
 class FullRefreshTest(TestCase):
 
     def setUp(self) -> None:
-        self._http_mocker = HttpMocker()
+        self._http_mocker = CustomHttpMocker()
         self._http_mocker.__enter__()
         _given_get_timezone(self._http_mocker)
         _given_read_schema(self._http_mocker)
@@ -133,18 +133,20 @@ class FullRefreshTest(TestCase):
     
     def tearDown(self) -> None:
         self._http_mocker.__exit__(None,None,None)
-
+        
         
     def test_given_one_page_when_read_then_return_records(self, uuid_mock, mock_auth) -> None:
         self._http_mocker.post(
             table_request().with_table(_TABLE).with_requestID(_REQUESTID).with_async().build(),
             snowflake_response("async_response", FieldPath("statementStatusUrl")).with_handle(_HANDLE).build()
         )
-        self._http_mocker.get(
-            table_request().with_handle(_HANDLE).build(is_get=True),
-            snowflake_response("response_get_table", JsonPath("$.'data'"))
-            .with_record( a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]")))
-            .build())
+        # self._http_mocker.get(
+        #     table_request().with_handle(_HANDLE).build(is_get=True),
+        #     snowflake_response("response_get_table", JsonPath("$.'data'"))
+        #     .with_record( a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]")))
+        #     .build())
+        
+        
 
 
         output = _read(_config(), sync_mode=SyncMode.full_refresh)

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -8,6 +8,7 @@ from airbyte_cdk.sources.source import TState
 from airbyte_cdk.test.catalog_builder import CatalogBuilder
 from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
 from inflection import parameterize
+import requests_mock
 from integration.response_builder import JsonPath, SnowflakeResponseBuilder, create_response_builder
 from integration.mocker import CustomHttpMocker, HttpMocker
 from airbyte_cdk.test.mock_http.response_builder import (
@@ -140,22 +141,22 @@ class FullRefreshTest(TestCase):
             table_request().with_table(_TABLE).with_requestID(_REQUESTID).with_async().build(),
             snowflake_response("async_response", FieldPath("statementStatusUrl")).with_handle(_HANDLE).build()
         )
+        
         self._http_mocker.get(
             table_request().with_handle(_HANDLE).build(is_get=True),
             snowflake_response("response_get_table", JsonPath("$.'data'"))
             .with_record( a_snowflake_response("response_get_table", JsonPath("$.'data'.[*]")))
             .build())
         
-        
-
-
         output = _read(_config(), sync_mode=SyncMode.full_refresh)
+        assert len(output.records)==1
 
     def test_given_three_pages_read_then_return_records(self, uuid_mock, mock_auth) -> None:
         self._http_mocker.post(
             table_request().with_table(_TABLE).with_requestID(_REQUESTID).with_async().build(),
             snowflake_response("async_response", FieldPath("statementStatusUrl")).with_handle(_HANDLE).build()
         )
+
         self._http_mocker.get(
             table_request().with_handle(_HANDLE).build(is_get=True),
             snowflake_response("response_get_table", JsonPath("$.'data'")).with_record(


### PR DESCRIPTION
Draft because  we need to merge snowflake-test-read in master before merging this one

## What
- test cursor set in state with 4 accepted types , full   refresh mode
- test retry on status code
- test error on status code

## Review guide

1. `integration/testtable`
2. `y.py`


## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
