### PR TITLE
Snowflake test incremental with state: tests implemented and passing

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/util_streams.py
+++ b/airbyte-integrations/connectors/source-snowflake/source_snowflake/streams/util_streams.py
@@ -276,10 +276,10 @@ class StreamLauncher(SnowflakeStream):
         if generic_type == "date":
             state_sql_condition = f"TO_TIMESTAMP({self.cursor_field})>=TO_TIMESTAMP('{current_state_value}')"
 
-        elif generic_type == "number":
+        if generic_type == "number":
             state_sql_condition = f"{self.cursor_field}>={current_state_value}"
 
-        elif generic_type == "string":
+        if generic_type == "string":
             state_sql_condition = f"{self.cursor_field}>='{current_state_value}'"
 
         return state_sql_condition

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -25,6 +25,7 @@ from integration.request_builder import SnowflakeRequestBuilder
 from integration.config import ConfigBuilder
 from integration.snowflake_stream_builder import SnowflakeStreamBuilder
 from source_snowflake import SourceSnowflake
+from test.state_builder import StateBuilder
 
 _WAREHOUSE = "WAREHOUSE"
 _DATABASE = "DATABASE"
@@ -493,6 +494,111 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
         assert most_recent_state.stream_descriptor == StreamDescriptor(name=self.stream_name)
         assert most_recent_state.stream_state == AirbyteStateBlob(TEST_COLUMN_14=expected_cursor_value)
+
+    @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
+    @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
+    @HttpMocker()
+    def test_incremental_with_initial_state_lower_than_highest_record_state_with_number_cursor(self, uuid_mock, mock_auth, http_mocker: HttpMocker) -> None:
+        _given_get_timezone(http_mocker)
+        _given_read_schema(http_mocker)
+        _given_table_catalog(http_mocker)
+        _given_table_with_primary_keys(http_mocker)
+
+        cursor_field = "ID"
+        id_index = 0
+        expected_cursor_value = 5
+        initial_state_value = 4
+        initial_state = {cursor_field: initial_state_value}
+        cursor_path = JsonPath(f"$.[{id_index}]")
+        cursor_generic_type = "number"
+
+        http_mocker.post(
+            table_request()
+            .with_table(_TABLE)
+            .with_requestID(_REQUESTID)
+            .with_cursor_field(cursor_field)
+            .with_cursor_generic_type(cursor_generic_type)
+            .with_state(initial_state)
+            .with_async()
+            .build(),
+            snowflake_response("async_response", FieldPath("statementStatusUrl"))
+            .with_handle(_HANDLE)
+            .build()
+        )
+
+        http_mocker.get(
+            table_request()
+            .with_handle(_HANDLE)
+            .build(is_get=True),
+            snowflake_response("response_get_table")
+            .with_record(self._a_record(cursor_path).with_cursor(4))
+            .with_record(self._a_record(cursor_path).with_cursor(5))
+            .build()
+        )
+
+        stream_builder = (SnowflakeStreamBuilder().with_name(self.stream_name)
+                          .with_cursor_field([cursor_field])
+                          .with_sync_mode(self.sync_mode))
+        catalog = CatalogBuilder().with_stream(stream_builder).build()
+        state = StateBuilder().with_stream_state(self.stream_name, initial_state).build()
+
+        output = self._read(_config(), catalog, state)
+        most_recent_state = output.most_recent_state
+
+        assert len(output.records) == 2
+        assert most_recent_state.stream_descriptor == StreamDescriptor(name=self.stream_name)
+        assert most_recent_state.stream_state == AirbyteStateBlob(ID=expected_cursor_value)
+    @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
+    @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
+    @HttpMocker()
+    def test_incremental_with_initial_state_higher_than_highest_record_state_with_number_cursor(self, uuid_mock, mock_auth, http_mocker: HttpMocker) -> None:
+        _given_get_timezone(http_mocker)
+        _given_read_schema(http_mocker)
+        _given_table_catalog(http_mocker)
+        _given_table_with_primary_keys(http_mocker)
+
+        cursor_field = "ID"
+        id_index = 0
+        initial_state_value = expected_cursor_value = 6
+        cursor_path = JsonPath(f"$.[{id_index}]")
+        initial_state = {cursor_field: initial_state_value}
+        cursor_generic_type = "number"
+
+        http_mocker.post(
+            table_request()
+            .with_table(_TABLE)
+            .with_requestID(_REQUESTID)
+            .with_cursor_field(cursor_field)
+            .with_cursor_generic_type(cursor_generic_type)
+            .with_state(initial_state)
+            .with_async()
+            .build(),
+            snowflake_response("async_response", FieldPath("statementStatusUrl"))
+            .with_handle(_HANDLE)
+            .build()
+        )
+
+        http_mocker.get(
+            table_request()
+            .with_handle(_HANDLE)
+            .build(is_get=True),
+            snowflake_response("response_get_table")
+            .with_record(self._a_record(cursor_path).with_cursor(4))
+            .with_record(self._a_record(cursor_path).with_cursor(5))
+            .build()
+        )
+
+        stream_builder = (SnowflakeStreamBuilder().with_name(self.stream_name)
+                          .with_cursor_field([cursor_field])
+                          .with_sync_mode(self.sync_mode))
+        catalog = CatalogBuilder().with_stream(stream_builder).build()
+        state = StateBuilder().with_stream_state(self.stream_name, initial_state).build()
+
+        output = self._read(_config(), catalog, state)
+        most_recent_state = output.most_recent_state
+
+        assert most_recent_state.stream_descriptor == StreamDescriptor(name=self.stream_name)
+        assert most_recent_state.stream_state == AirbyteStateBlob(ID=expected_cursor_value)
 
     @classmethod
     def _read(cls,

--- a/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
+++ b/airbyte-integrations/connectors/source-snowflake/unit_tests/integration/test_table.py
@@ -715,6 +715,119 @@ class IncrementalTest(TestCase):
         assert most_recent_state.stream_descriptor == StreamDescriptor(name=self.stream_name)
         assert most_recent_state.stream_state == AirbyteStateBlob(TEST_COLUMN_20=expected_cursor_value)
 
+
+    @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
+    @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
+    @HttpMocker()
+    def test_incremental_with_initial_state_lower_than_highest_record_state_with_timestamp_time_zone_cursor(self, uuid_mock, mock_auth,
+                                                                                             http_mocker: HttpMocker) -> None:
+        _given_get_timezone(http_mocker)
+        _given_read_schema(http_mocker)
+        _given_table_catalog(http_mocker)
+        _given_table_with_primary_keys(http_mocker)
+
+        cursor_field = "TEST_COLUMN_26"
+        id_index = 18
+        expected_cursor_value = "2018-03-22T12:00:01.123001+05:00"
+        cursor_path = JsonPath(f"$.[{id_index}]")
+
+        initial_state_value = "2018-03-20T12:00:01.123001+05:00"
+        initial_state = {cursor_field: initial_state_value}
+        cursor_generic_type = "timestamp_with_timezone"
+
+        http_mocker.post(
+            table_request()
+            .with_table(_TABLE)
+            .with_requestID(_REQUESTID)
+            .with_cursor_field(cursor_field)
+            .with_cursor_generic_type(cursor_generic_type)
+            .with_state(initial_state)
+            .with_async()
+            .build(),
+            snowflake_response("async_response", FieldPath("statementStatusUrl"))
+            .with_handle(_HANDLE)
+            .build()
+        )
+
+        http_mocker.get(
+            table_request()
+            .with_handle(_HANDLE)
+            .build(is_get=True),
+            snowflake_response("response_get_table")
+            .with_record(self._a_record(cursor_path).with_cursor("1521702000.123000000 1740"))
+            .with_record(self._a_record(cursor_path).with_cursor("1521702001.123000000 1740"))
+            .with_record(self._a_record(cursor_path).with_cursor("1521702001.123001000 1740"))
+            .build()
+        )
+
+        stream_builder = (SnowflakeStreamBuilder().with_name(self.stream_name)
+                          .with_cursor_field([cursor_field])
+                          .with_sync_mode(self.sync_mode))
+        catalog = CatalogBuilder().with_stream(stream_builder).build()
+        state = StateBuilder().with_stream_state(self.stream_name, initial_state).build()
+
+        output = self._read(_config(), catalog, state)
+        most_recent_state = output.most_recent_state
+
+        assert len(output.records) == 3
+        assert most_recent_state.stream_descriptor == StreamDescriptor(name=self.stream_name)
+        assert most_recent_state.stream_state == AirbyteStateBlob(TEST_COLUMN_26=expected_cursor_value)
+
+    @mock.patch("source_snowflake.streams.snowflake_parent_stream.uuid.uuid4", return_value=_REQUESTID)
+    @mock.patch("source_snowflake.source.SnowflakeJwtAuthenticator")
+    @HttpMocker()
+    def test_incremental_with_initial_state_higher_than_highest_record_state_with_timestamp_time_zone_cursor(self, uuid_mock, mock_auth,
+                                                                                                http_mocker: HttpMocker) -> None:
+        _given_get_timezone(http_mocker)
+        _given_read_schema(http_mocker)
+        _given_table_catalog(http_mocker)
+        _given_table_with_primary_keys(http_mocker)
+
+        cursor_field = "TEST_COLUMN_26"
+        id_index = 18
+        cursor_path = JsonPath(f"$.[{id_index}]")
+
+        initial_state_value = expected_cursor_value = "2018-03-25T12:00:01.123001+05:00"
+        initial_state = {cursor_field: initial_state_value}
+        cursor_generic_type = "timestamp_with_timezone"
+
+        http_mocker.post(
+            table_request()
+            .with_table(_TABLE)
+            .with_requestID(_REQUESTID)
+            .with_cursor_field(cursor_field)
+            .with_cursor_generic_type(cursor_generic_type)
+            .with_state(initial_state)
+            .with_async()
+            .build(),
+            snowflake_response("async_response", FieldPath("statementStatusUrl"))
+            .with_handle(_HANDLE)
+            .build()
+        )
+
+        http_mocker.get(
+            table_request()
+            .with_handle(_HANDLE)
+            .build(is_get=True),
+            snowflake_response("response_get_table")
+            .with_record(self._a_record(cursor_path).with_cursor("1521702000.123000000 1740"))
+            .with_record(self._a_record(cursor_path).with_cursor("1521702001.123000000 1740"))
+            .with_record(self._a_record(cursor_path).with_cursor("1521702001.123001000 1740"))
+            .build()
+        )
+
+        stream_builder = (SnowflakeStreamBuilder().with_name(self.stream_name)
+                          .with_cursor_field([cursor_field])
+                          .with_sync_mode(self.sync_mode))
+        catalog = CatalogBuilder().with_stream(stream_builder).build()
+        state = StateBuilder().with_stream_state(self.stream_name, initial_state).build()
+
+        output = self._read(_config(), catalog, state)
+        most_recent_state = output.most_recent_state
+
+        assert most_recent_state.stream_descriptor == StreamDescriptor(name=self.stream_name)
+        assert most_recent_state.stream_state == AirbyteStateBlob(TEST_COLUMN_26=expected_cursor_value)
+
     @classmethod
     def _read(cls,
               config_builder: ConfigBuilder,


### PR DESCRIPTION
## What
Test of incremental with initial state with 2 cases :
- state lower than the latest record value ->  right number of record + expected state = latest record value
- state higher than the latest record value -> expected state = initial value of state
for every cursor type

## How
2 tests per cursor field type (4 types depending on generic type that sets the correct sql statement)

## Review guide
request_builder.py 

## User Impact
User can test incremental with state

## Can this PR be safely reverted and rolled back?
YES 💚